### PR TITLE
Align with rh-openjdk/jdk#1 final version

### DIFF
--- a/ExportDSATest.java
+++ b/ExportDSATest.java
@@ -70,17 +70,16 @@ public class ExportDSATest {
         });
 
         CK_ATTRIBUTE[] exportAttrs = {
-                new CK_ATTRIBUTE(CKA_KEY_TYPE, CKK_DSA),
                 new CK_ATTRIBUTE(CKA_VALUE, new byte[0]),
                 new CK_ATTRIBUTE(CKA_PRIME, new byte[0]),
                 new CK_ATTRIBUTE(CKA_SUBPRIME, new byte[0]),
                 new CK_ATTRIBUTE(CKA_BASE, new byte[0])
         };
         p11.C_GetAttributeValue(session, keyId, exportAttrs);
-        assertEquals("Exported value", key.getX(), exportAttrs[1].getBigInteger());
-        assertEquals("Exported prime", key.getParams().getP(), exportAttrs[2].getBigInteger());
-        assertEquals("Exported subprime", key.getParams().getQ(), exportAttrs[3].getBigInteger());
-        assertEquals("Exported base", key.getParams().getG(), exportAttrs[4].getBigInteger());
+        assertEquals("Exported value", key.getX(), exportAttrs[0].getBigInteger());
+        assertEquals("Exported prime", key.getParams().getP(), exportAttrs[1].getBigInteger());
+        assertEquals("Exported subprime", key.getParams().getQ(), exportAttrs[2].getBigInteger());
+        assertEquals("Exported base", key.getParams().getG(), exportAttrs[3].getBigInteger());
 
         releaseSession(sunp11, session);
     }

--- a/ExportDSATest.java
+++ b/ExportDSATest.java
@@ -76,10 +76,12 @@ public class ExportDSATest {
                 new CK_ATTRIBUTE(CKA_BASE, new byte[0])
         };
         p11.C_GetAttributeValue(session, keyId, exportAttrs);
-        assertEquals("Exported value", key.getX(), exportAttrs[0].getBigInteger());
-        assertEquals("Exported prime", key.getParams().getP(), exportAttrs[1].getBigInteger());
-        assertEquals("Exported subprime", key.getParams().getQ(), exportAttrs[2].getBigInteger());
-        assertEquals("Exported base", key.getParams().getG(), exportAttrs[3].getBigInteger());
+
+        int i = 0;
+        assertEquals("Exported value", key.getX(), exportAttrs[i++].getBigInteger());
+        assertEquals("Exported prime", key.getParams().getP(), exportAttrs[i++].getBigInteger());
+        assertEquals("Exported subprime", key.getParams().getQ(), exportAttrs[i++].getBigInteger());
+        assertEquals("Exported base", key.getParams().getG(), exportAttrs[i++].getBigInteger());
 
         releaseSession(sunp11, session);
     }

--- a/ExportECTest.java
+++ b/ExportECTest.java
@@ -67,13 +67,12 @@ public class ExportECTest {
         });
 
         CK_ATTRIBUTE[] exportAttrs = {
-                new CK_ATTRIBUTE(CKA_KEY_TYPE, CKK_EC),
                 new CK_ATTRIBUTE(CKA_VALUE, new byte[0]),
                 new CK_ATTRIBUTE(CKA_EC_PARAMS, new byte[0])
         };
         p11.C_GetAttributeValue(session, keyId, exportAttrs);
-        assertEquals("Exported value", key.getS(), exportAttrs[1].getBigInteger());
-        assertEquals("Exported params", CurveDB.lookup(key.getParams()).getEncoded(), exportAttrs[2].getByteArray());
+        assertEquals("Exported value", key.getS(), exportAttrs[0].getBigInteger());
+        assertEquals("Exported params", CurveDB.lookup(key.getParams()).getEncoded(), exportAttrs[1].getByteArray());
 
         releaseSession(sunp11, session);
     }

--- a/ExportECTest.java
+++ b/ExportECTest.java
@@ -71,8 +71,10 @@ public class ExportECTest {
                 new CK_ATTRIBUTE(CKA_EC_PARAMS, new byte[0])
         };
         p11.C_GetAttributeValue(session, keyId, exportAttrs);
-        assertEquals("Exported value", key.getS(), exportAttrs[0].getBigInteger());
-        assertEquals("Exported params", CurveDB.lookup(key.getParams()).getEncoded(), exportAttrs[1].getByteArray());
+
+        int i = 0;
+        assertEquals("Exported value", key.getS(), exportAttrs[i++].getBigInteger());
+        assertEquals("Exported params", CurveDB.lookup(key.getParams()).getEncoded(), exportAttrs[i++].getByteArray());
 
         releaseSession(sunp11, session);
     }

--- a/ExportRSATest.java
+++ b/ExportRSATest.java
@@ -83,13 +83,12 @@ public class ExportRSATest {
         });
 
         CK_ATTRIBUTE[] exportAttrs = {
-                new CK_ATTRIBUTE(CKA_KEY_TYPE, CKK_RSA),
                 new CK_ATTRIBUTE(CKA_MODULUS, new byte[0]),
                 new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT, new byte[0])
         };
         p11.C_GetAttributeValue(session, keyId, exportAttrs);
-        assertEquals("Exported modulus", key.getModulus(), exportAttrs[1].getBigInteger());
-        assertEquals("Exported private exponent", key.getPrivateExponent(), exportAttrs[2].getBigInteger());
+        assertEquals("Exported modulus", key.getModulus(), exportAttrs[0].getBigInteger());
+        assertEquals("Exported private exponent", key.getPrivateExponent(), exportAttrs[1].getBigInteger());
 
         releaseSession(sunp11, session);
     }

--- a/ExportRSATest.java
+++ b/ExportRSATest.java
@@ -84,13 +84,25 @@ public class ExportRSATest {
 
         CK_ATTRIBUTE[] exportAttrs = {
                 new CK_ATTRIBUTE(CKA_MODULUS, new byte[0]),
-                new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT, new byte[0])
+                new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT, new byte[0]),
+                new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT, new byte[0]),
+                new CK_ATTRIBUTE(CKA_PRIME_1, new byte[0]),
+                new CK_ATTRIBUTE(CKA_PRIME_2, new byte[0]),
+                new CK_ATTRIBUTE(CKA_EXPONENT_1, new byte[0]),
+                new CK_ATTRIBUTE(CKA_EXPONENT_2, new byte[0]),
+                new CK_ATTRIBUTE(CKA_COEFFICIENT, new byte[0]),
         };
         p11.C_GetAttributeValue(session, keyId, exportAttrs);
 
         int i = 0;
         assertEquals("Exported modulus", key.getModulus(), exportAttrs[i++].getBigInteger());
+        assertEquals("Exported public exponent", key.getPublicExponent(), exportAttrs[i++].getBigInteger());
         assertEquals("Exported private exponent", key.getPrivateExponent(), exportAttrs[i++].getBigInteger());
+        assertEquals("Exported prime P", key.getPrimeP(), exportAttrs[i++].getBigInteger());
+        assertEquals("Exported prime Q", key.getPrimeQ(), exportAttrs[i++].getBigInteger());
+        assertEquals("Exported prime exponent P", key.getPrimeExponentP(), exportAttrs[i++].getBigInteger());
+        assertEquals("Exported prime exponent Q", key.getPrimeExponentQ(), exportAttrs[i++].getBigInteger());
+        assertEquals("Exported coefficient", key.getCrtCoefficient(), exportAttrs[i++].getBigInteger());
 
         releaseSession(sunp11, session);
     }

--- a/ExportRSATest.java
+++ b/ExportRSATest.java
@@ -87,8 +87,10 @@ public class ExportRSATest {
                 new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT, new byte[0])
         };
         p11.C_GetAttributeValue(session, keyId, exportAttrs);
-        assertEquals("Exported modulus", key.getModulus(), exportAttrs[0].getBigInteger());
-        assertEquals("Exported private exponent", key.getPrivateExponent(), exportAttrs[1].getBigInteger());
+
+        int i = 0;
+        assertEquals("Exported modulus", key.getModulus(), exportAttrs[i++].getBigInteger());
+        assertEquals("Exported private exponent", key.getPrivateExponent(), exportAttrs[i++].getBigInteger());
 
         releaseSession(sunp11, session);
     }


### PR DESCRIPTION
Hi @akashche, hope you are doing well :)

This PR implements some little improvements to align with the final version of rh-openjdk/jdk#1, and in line with some items discussed in my feedback email. I've made the changes to better test the 11u backport (rh-openjdk/jdk11u#6), so I appreciate the effort invested in this test suite!

Merge this only if you want to keep this repository synced, I'll keep my fork as a backup in case you want to delete it.